### PR TITLE
Move SkillID parsing into existing try/except KeyError blocks

### DIFF
--- a/Process_DL_Data.py
+++ b/Process_DL_Data.py
@@ -290,12 +290,14 @@ def process_CharaData(row, existing_data):
         new_row[mfb_k] = row['_' + mfb_k]
     new_row['MinDef'] = row['_MinDef']
     new_row['DefCoef'] = row['_DefCoef']
-    new_row['Skill1ID'] = row['_Skill1']
-    new_row['Skill2ID'] = row['_Skill2']
     try:
+        new_row['Skill1ID'] = row['_Skill1']
+        new_row['Skill2ID'] = row['_Skill2']
         new_row['Skill1Name'] = get_label(SKILL_DATA_NAMES[row['_Skill1']])
         new_row['Skill2Name'] = get_label(SKILL_DATA_NAMES[row['_Skill2']])
     except KeyError:
+        new_row['Skill1ID'] = ''
+        new_row['Skill2ID'] = ''
         new_row['Skill1Name'] = ''
         new_row['Skill2Name'] = ''
 
@@ -346,11 +348,11 @@ def process_Dragon(row, existing_data):
     new_row['MaxHp'] = row['_MaxHp']
     new_row['MinAtk'] = row['_MinAtk']
     new_row['MaxAtk'] = row['_MaxAtk']
-    new_row['SkillID'] = row['_Skill1']
-    new_row['SkillName'] = get_label(SKILL_DATA_NAMES[row['_Skill1']])
     try:
+        new_row['SkillID'] = row['_Skill1']
         new_row['SkillName'] = get_label(SKILL_DATA_NAMES[row['_Skill1']])
     except KeyError:
+        new_row['SkillID'] = ''
         new_row['SkillName'] = ''
     for i in (1, 2):
         for j in (1, 2):
@@ -761,7 +763,7 @@ def process_WeaponData(row, existing_data):
         new_row['Skill'] = row['_Skill']
         new_row['SkillName'] = get_label(SKILL_DATA_NAMES[row['_Skill']])
     except KeyError:
-        new_row['SkillID'] = ''
+        new_row['Skill'] = ''
         new_row['SkillName'] = ''
     new_row['Abilities11'] = row['_Abilities11']
     new_row['Abilities21'] = row['_Abilities21']


### PR DESCRIPTION
For consistency, put SkillID and SkillName declarations into the same try except blocks, and add missing except fallbacks for SkillID fields where necessary. Some SkillName declarations were redundant previously, as they existed both out of and inside the try/except block.

In one case, the try case ('Skill') did not match the except case ('SkillID') so updated that as well.