### PR TITLE
Parse questData PayEntityType into new OtherCostType field

### DIFF
--- a/Process_DL_Data.py
+++ b/Process_DL_Data.py
@@ -594,8 +594,8 @@ def process_MissionData(row, existing_data):
 
 def process_QuestData(row, existing_data):
     pay_entity_type_dict = {
-        "20" : 'OtherworldFragmentCost',
-        "26" : 'AstralPieceCost',
+        "20" : get_raid_item_label(row['_PayEntityId']),
+        "26" : 'Astral Piece',
     }
 
     new_row = {}
@@ -642,7 +642,8 @@ def process_QuestData(row, existing_data):
     new_row['CampaignGetherwingCost'] = row['_CampaignStaminaMulti']
 
     if row['_PayEntityType'] in pay_entity_type_dict:
-        new_row[pay_entity_type_dict[row['_PayEntityType']]] = row['_PayEntityQuantity']
+        new_row['OtherCostType'] = pay_entity_type_dict[row['_PayEntityType']]
+        new_row['OtherCostQuantity'] = row['_PayEntityQuantity']
 
     new_row['ClearTermsType'] = get_label('QUEST_CLEAR_CONDITION_{}'.format(row['_ClearTermsType']))
 

--- a/Process_DL_Data.py
+++ b/Process_DL_Data.py
@@ -641,8 +641,9 @@ def process_QuestData(row, existing_data):
     new_row['GetherwingCost'] = row['_PayStaminaMulti']
     new_row['CampaignGetherwingCost'] = row['_CampaignStaminaMulti']
 
-    if row['_PayEntityType'] in pay_entity_type_dict:
-        new_row['OtherCostType'] = pay_entity_type_dict[row['_PayEntityType']]
+    if row['_PayEntityType'] != '0':
+        new_row['OtherCostType'] = pay_entity_type_dict.get(row['_PayEntityType'],
+            '{}: {}'.format(row['_PayEntityType'], row['_PayEntityId']))
         new_row['OtherCostQuantity'] = row['_PayEntityQuantity']
 
     new_row['ClearTermsType'] = get_label('QUEST_CLEAR_CONDITION_{}'.format(row['_ClearTermsType']))


### PR DESCRIPTION
As prepared in https://dragalialost.gamepedia.com/index.php?title=Template:QuestDisplay&diff=68216&oldid=67628, Quest pay entities that are not normal units like stamina or wings will be grouped similar to the game hierarchy as a single type-quantity pair in the output template, instead of individually having parameters. Updating the parsing to reflect this.